### PR TITLE
Add skeleton for voice-first planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# assist
+# Voice-First Routine Planner
+
+This project contains a minimal prototype for a voice-based routine-planning assistant. It uses a Next.js client with WebSocket streaming to a FastAPI backend.
+
+## Layout
+
+```
+/              # root
+├── client/    # Next.js SPA
+│   ├── pages/
+│   │   ├── index.tsx        # ask name
+│   │   └── chat.tsx         # voice session
+│   ├── components/
+│   │   ├── MicButton.tsx    # mute / push-to-talk
+│   │   └── AgentBubble.tsx  # avatar + audio
+│   ├── hooks/
+│   │   ├── useAudioStream.ts     # mic → Opus chunks
+│   │   ├── useWSChat.ts          # WS connect / protocol
+│   │   └── useAudioPlayer.ts     # play incoming PCM
+│   └── lib/codecs/
+│
+├── server/
+│   ├── main.py              # FastAPI bootstrap; /ws endpoint
+│   ├── pipelines/
+│   │   ├── endpoint.py           # VAD + punctuation rules
+│   │   ├── stt.py                # streaming Whisper
+│   │   ├── chat.py               # incremental LLM
+│   │   └── tts.py                # streaming TTS
+│   └── utils/
+│       └── audio.py            # resample, framing
+|
+├── shared/schema.ts          # common types
+└── README.md
+```
+
+## Development
+
+```bash
+# install Python deps
+cd server
+pip install -r requirements.txt
+
+# run FastAPI server
+uvicorn main:app --reload
+
+# in another terminal, run Next.js client
+cd ../client
+npm install
+npm run dev
+```
+
+This repository only includes minimal scaffolding. The detailed interview logic, streaming audio handling and OpenAI integrations still need to be implemented.

--- a/client/components/AgentBubble.tsx
+++ b/client/components/AgentBubble.tsx
@@ -1,0 +1,3 @@
+export default function AgentBubble({ text }: { text: string }) {
+  return <div style={{ margin: '8px 0', padding: 10, background: '#eee' }}>{text}</div>
+}

--- a/client/components/MicButton.tsx
+++ b/client/components/MicButton.tsx
@@ -1,0 +1,10 @@
+import { useAudioStream } from '../hooks/useAudioStream'
+
+export default function MicButton({ onData }: { onData: (d: ArrayBuffer) => void }) {
+  const { start, stop, active } = useAudioStream(onData)
+  return (
+    <button onMouseDown={start} onMouseUp={stop} style={{ padding: 20 }}>
+      {active ? 'Recording...' : 'Hold to Talk'}
+    </button>
+  )
+}

--- a/client/hooks/useAudioPlayer.ts
+++ b/client/hooks/useAudioPlayer.ts
@@ -1,0 +1,9 @@
+export default function useAudioPlayer() {
+  const play = (data: ArrayBuffer) => {
+    const blob = new Blob([data], { type: 'audio/wav' })
+    const url = URL.createObjectURL(blob)
+    const audio = new Audio(url)
+    audio.play()
+  }
+  return { play }
+}

--- a/client/hooks/useAudioStream.ts
+++ b/client/hooks/useAudioStream.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+
+export function useAudioStream(onData: (d: ArrayBuffer) => void) {
+  const [active, setActive] = useState(false)
+  let mediaRecorder: MediaRecorder | null = null
+
+  const start = async () => {
+    if (active) return
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    mediaRecorder = new MediaRecorder(stream)
+    mediaRecorder.ondataavailable = e => onData(e.data.arrayBuffer())
+    mediaRecorder.start(20)
+    setActive(true)
+  }
+
+  const stop = () => {
+    if (mediaRecorder && active) {
+      mediaRecorder.stop()
+      setActive(false)
+    }
+  }
+
+  return { start, stop, active }
+}

--- a/client/hooks/useWSChat.ts
+++ b/client/hooks/useWSChat.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { WSMessage } from '../../shared/schema'
+import useAudioPlayer from './useAudioPlayer'
+
+export default function useWSChat() {
+  const [messages, setMessages] = useState<string[]>([])
+  const { play } = useAudioPlayer()
+  const [ws, setWs] = useState<WebSocket | null>(null)
+
+  useEffect(() => {
+    const socket = new WebSocket('ws://localhost:8000/ws')
+    socket.binaryType = 'arraybuffer'
+    socket.onmessage = (event) => {
+      if (typeof event.data === 'string') {
+        setMessages(m => [...m, event.data])
+      } else {
+        play(event.data)
+      }
+    }
+    setWs(socket)
+    return () => socket.close()
+  }, [])
+
+  const sendAudio = (buf: ArrayBuffer) => {
+    ws?.send(buf)
+  }
+
+  return { messages, sendAudio }
+}

--- a/client/lib/codecs/index.ts
+++ b/client/lib/codecs/index.ts
@@ -1,0 +1,4 @@
+// Placeholder for audio encoding helpers
+export function encodeOpus(buf: ArrayBuffer): ArrayBuffer {
+  return buf
+}

--- a/client/next-env.d.ts
+++ b/client/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "client",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2"
+  }
+}

--- a/client/pages/chat.tsx
+++ b/client/pages/chat.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router'
+import MicButton from '../components/MicButton'
+import AgentBubble from '../components/AgentBubble'
+import useWSChat from '../hooks/useWSChat'
+
+export default function Chat() {
+  const router = useRouter()
+  const { name } = router.query as { name?: string }
+  const { messages, sendAudio } = useWSChat()
+
+  return (
+    <div style={{ padding: 40 }}>
+      <h2>Hello {name}</h2>
+      <div>
+        {messages.map((m, i) => (
+          <AgentBubble key={i} text={m} />
+        ))}
+      </div>
+      <MicButton onData={sendAudio} />
+    </div>
+  )
+}

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+
+export default function Home() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.push(`/chat?name=${encodeURIComponent(name)}`)
+  }
+
+  return (
+    <div style={{ padding: 40 }}>
+      <h1>Welcome</h1>
+      <form onSubmit={handleSubmit}>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Your name" />
+        <button type="submit">Start</button>
+      </form>
+    </div>
+  )
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, WebSocket
+from fastapi.responses import HTMLResponse
+from fastapi.middleware.cors import CORSMiddleware
+import asyncio
+
+app = FastAPI()
+
+# allow local dev
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
+def root():
+    return HTMLResponse("Voice Planner backend running")
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            data = await ws.receive_bytes()
+            # TODO: process Opus/PCM frames
+            # placeholder: echo back
+            await ws.send_bytes(data)
+    except Exception:
+        pass
+    finally:
+        await ws.close()

--- a/server/pipelines/chat.py
+++ b/server/pipelines/chat.py
@@ -1,0 +1,5 @@
+"""Incremental LLM chat via OpenAI ChatCompletion."""
+
+async def stream_chat(prompt: str):
+    # TODO: integrate with OpenAI ChatCompletion stream
+    yield "Hello"  # placeholder

--- a/server/pipelines/endpoint.py
+++ b/server/pipelines/endpoint.py
@@ -1,0 +1,5 @@
+"""Voice activity detection and text endpointing utilities."""
+
+async def commit_text(partial: str) -> bool:
+    """Return True if partial text forms a complete sentence."""
+    return partial.endswith(('.', '?', '!'))

--- a/server/pipelines/stt.py
+++ b/server/pipelines/stt.py
@@ -1,0 +1,7 @@
+"""Streaming speech-to-text using OpenAI Whisper placeholder."""
+
+async def stream_whisper(audio_chunks):
+    for chunk in audio_chunks:
+        # TODO: send to OpenAI Whisper with stream=True
+        text = ""  # placeholder
+        yield text

--- a/server/pipelines/tts.py
+++ b/server/pipelines/tts.py
@@ -1,0 +1,5 @@
+"""Streaming text-to-speech placeholder."""
+
+async def stream_tts(text: str):
+    # TODO: call TTS service
+    yield b""  # PCM bytes

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+websockets
+openai

--- a/server/utils/audio.py
+++ b/server/utils/audio.py
@@ -1,0 +1,5 @@
+"""Audio utilities such as resampling and framing."""
+
+def resample(data: bytes, in_rate: int, out_rate: int) -> bytes:
+    # TODO: implement resampling
+    return data

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,0 +1,4 @@
+export interface WSMessage {
+  type: 'audio' | 'text';
+  payload: ArrayBuffer | string;
+}


### PR DESCRIPTION
## Summary
- set up Next.js scaffold under `client`
- create FastAPI backend with `/ws` endpoint
- add placeholder audio/LLM pipeline modules
- document layout and dev steps in README

## Testing
- `python -m py_compile server/main.py server/pipelines/*.py server/utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68682d6685f88332801eb4aea19f1c42